### PR TITLE
Feature docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,47 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
+{
+	"name": "Existing Docker Compose (Extend)",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"../docker-compose.yml",
+		"docker-compose.yml"
+	],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "spark",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python"
+			]
+		}
+	}
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  # Update this to the name of the service you want to work with in your docker-compose.yml file
+  spark:
+    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer 
+    # folder. Note that the path of the Dockerfile and context is relative to the *primary* 
+    # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
+    # array). The sample below assumes your primary file is in the root of your project.
+    #
+    # build:
+    #   context: .
+    #   dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+      # Update this to wherever you want VS Code to mount the folder of your project
+      - ..:/workspaces:cached
+
+    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
+    # cap_add:
+    #   - SYS_PTRACE
+    # security_opt:
+    #   - seccomp:unconfined
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+ 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,130 @@
+ARG BASE_IMAGE=ubuntu:24.04
+# ARG BASE_IMAGE=osrf/ros:jazzy-simulation
+ARG WITH_ROS=false
+
+####################
+# 
+# Base Image
+# 
+# Includes Miniconda, CUDA JIT, and OpenGL and system dependencies for MuJoCo.
+# Defaults to Ubuntu, but can be overridden by the `BASE_IMAGE` build arg 
+# for example, to use a ROS jazzy simulation image, set BASE_IMAGE=osrf/ros:jazzy-simulation
+####################
+
+FROM ${BASE_IMAGE} AS spark-base
+
+# Environment Variables for Conda and CUDA
+ENV DEBIAN_FRONTEND=noninteractive
+ARG CONDA_PREFIX=/opt/conda
+ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS=yes
+ENV CUDA_HOME=/usr/local/cuda
+ENV PATH="${CONDA_PREFIX}/bin:${CUDA_HOME}/bin:${PATH}"
+# for GPU Rendering
+ENV LD_LIBRARY_PATH="${CUDA_HOME}/lib64:${CUDA_HOME}/compat"
+ENV LIBGL_ALWAYS_SOFTWARE=0
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=graphics,compute,utility
+# for MuJoCo
+ENV MUJOCO_GL=glx
+ENV __GLX_VENDOR_LIBRARY_NAME=nvidia
+# IMPORTANT: for WSLg OpenGL support in WSL2 with NVIDIA GPU
+ENV LD_LIBRARY_PATH=/usr/lib/wsl/lib:${LD_LIBRARY_PATH}
+
+# Install OpenGL and system dependencies for MuJoCo
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    gnupg \
+    wget \
+    git \
+    libgl1 \
+    libglvnd0 \
+    libglx0 \
+    mesa-utils \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender1 \
+    libgtk-3-0 \
+    && rm -rf /var/lib/apt/lists/*
+    
+# Install NVIDIA CUDA toolkit Numba and CUDA JIT-compilation.
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb -O /tmp/cuda-keyring.deb && \
+    dpkg -i /tmp/cuda-keyring.deb && \
+    rm /tmp/cuda-keyring.deb && \
+    apt-get update && apt-get install -y --no-install-recommends \
+    cuda-compiler-12-6 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Miniconda
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh && \
+    bash /tmp/miniconda.sh -b -u -p /opt/conda && \
+    rm /tmp/miniconda.sh && \
+    conda init --all
+
+
+# Install ROS 2 dependencies
+# Uncomment the following and add desired ROS dependencies
+# 
+# RUN if [ "${WITH_ROS}" = "true" ]; then \
+#     apt-get update && apt-get install -y --no-install-recommends \
+#     ros-${ROS_DISTRO}-rviz2 \
+#     ros-${ROS_DISTRO}-rviz-default-plugins \
+#     ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+#     && apt-get clean \
+#     && rm -rf /var/lib/apt/lists/*; \
+#     fi
+
+# Update bash config to source ROS setup script if ROS is included in the image
+RUN if [ "${WITH_ROS}" = "true" ]; then \
+        echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /etc/bash.bashrc; \
+    fi
+
+CMD [ "/bin/bash" ]
+
+
+####################
+#
+# Runtime Image 
+# 
+# Clones the Spark repository main branch and runs the installation script 
+# to set up the Spark application and its dependencies.
+####################
+
+FROM spark-base AS spark
+ARG USE_REMOTE_SRC=false
+
+WORKDIR /home/spark
+
+# Copy SPARK local repo
+COPY . /home/spark/spark
+# Optionally, instead use the remote repo source hosted on Github to install Spark
+# if USE_REMOTE_SRC is set "true"
+RUN if [ "${USE_REMOTE_SRC}" = "true" ]; then \
+rm -rf /home/spark/spark && \
+git clone -b main https://github.com/intelligent-control-lab/spark.git spark; \
+fi
+
+# clean conda cache and install SPARK
+# RUN conda clean --all -y 2>/dev/null
+RUN  cd spark && \
+chmod +x install.sh && \
+./install.sh \
+--name spark \
+--python 3.10 \
+# Install ROS dependencies if WITH_ROS is true
+$(if [ "${WITH_ROS}" = "true" ]; then echo "--ros"; fi)
+
+# Update bash config to activate the conda environment on login
+RUN echo "conda activate spark" >> /home/spark/.bashrc
+
+# Create a new user named 'spark'
+RUN useradd -ms /bin/bash spark
+# switch to the spark user
+RUN chown -R spark:spark /home/spark /opt/conda
+USER spark
+
+WORKDIR /home/spark/spark
+
+ENV DEBIAN_FRONTEND=readline
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 ARG BASE_IMAGE=ubuntu:24.04
 # ARG BASE_IMAGE=osrf/ros:jazzy-simulation
-ARG WITH_ROS=false
 
 ####################
 # 
@@ -13,6 +12,7 @@ ARG WITH_ROS=false
 
 FROM ${BASE_IMAGE} AS spark-base
 
+ARG WITH_ROS=false
 # Specify a miniconda3. (see versions here https://repo.anaconda.com/miniconda/)
 ARG CONAD_VERSION=py313_26.1.1-1
 # ARG CONAD_VERSION=latest
@@ -64,7 +64,7 @@ RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-${CONAD_VERSION}-Linux-x86_64.sh -O /tmp/miniconda.sh && \
     bash /tmp/miniconda.sh -b -u -p /opt/conda && \
     rm /tmp/miniconda.sh && \
-    conda init --all
+    conda init --all --system
 
 
 # Install ROS 2 dependencies
@@ -96,6 +96,7 @@ CMD [ "/bin/bash" ]
 ####################
 
 FROM spark-base AS spark
+ARG WITH_ROS=false
 ARG PYTHON_VERSION=3.10
 ARG USE_REMOTE_SRC=false
 
@@ -120,14 +121,15 @@ chmod +x install.sh && \
 # Install ROS dependencies if WITH_ROS is true
 $(if [ "${WITH_ROS}" = "true" ]; then echo "--ros"; fi)
 
-# Update bash config to activate the conda environment on login
-RUN echo "conda activate spark" >> /home/spark/.bashrc
-
 # Create a new user named 'spark'
-RUN useradd -ms /bin/bash spark
+# RUN useradd -ms /bin/bash spark
 # switch to the spark user
 # RUN chown -R spark:spark /home/spark /opt/conda
-USER spark
+# USER spark
+
+# Update bash config to activate the conda environment on login
+RUN conda init --all 
+RUN echo "conda activate spark" >> /root/.bashrc
 
 WORKDIR /home/spark/spark
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,7 @@ CMD [ "/bin/bash" ]
 ####################
 
 FROM spark-base AS spark
+ARG PYTHON_VERSION=3.10
 ARG USE_REMOTE_SRC=false
 
 WORKDIR /home/spark
@@ -115,7 +116,7 @@ RUN  cd spark && \
 chmod +x install.sh && \
 ./install.sh \
 --name spark \
---python 3.10 \
+--python ${PYTHON_VERSION} \
 # Install ROS dependencies if WITH_ROS is true
 $(if [ "${WITH_ROS}" = "true" ]; then echo "--ros"; fi)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ ARG WITH_ROS=false
 
 FROM ${BASE_IMAGE} AS spark-base
 
+# Specify a miniconda3. (see versions here https://repo.anaconda.com/miniconda/)
+ARG CONAD_VERSION=py313_26.1.1-1
+# ARG CONAD_VERSION=latest
+
 # Environment Variables for Conda and CUDA
 ENV DEBIAN_FRONTEND=noninteractive
 ARG CONDA_PREFIX=/opt/conda
@@ -57,7 +61,7 @@ RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86
     && rm -rf /var/lib/apt/lists/*
 
 # Install Miniconda
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh && \
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-${CONAD_VERSION}-Linux-x86_64.sh -O /tmp/miniconda.sh && \
     bash /tmp/miniconda.sh -b -u -p /opt/conda && \
     rm /tmp/miniconda.sh && \
     conda init --all
@@ -121,7 +125,7 @@ RUN echo "conda activate spark" >> /home/spark/.bashrc
 # Create a new user named 'spark'
 RUN useradd -ms /bin/bash spark
 # switch to the spark user
-RUN chown -R spark:spark /home/spark /opt/conda
+# RUN chown -R spark:spark /home/spark /opt/conda
 USER spark
 
 WORKDIR /home/spark/spark

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ x-service-common: &service-common
   gpus: all
   shm_size: 2g # increase shared memory size for MuJoCo
   working_dir: /home/spark/spark
-  user: ${UID_UID}
   environment: &env-common
     # required to prevent excessive thread creation
     OMP_NUM_THREADS: 4
@@ -24,7 +23,7 @@ x-service-common: &service-common
 
 services:
   # Default Spark container (w/o ROS) 
-  spark:
+  spark-default:
     <<: *service-common
     build:
       <<: *build-common
@@ -69,4 +68,3 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
     profiles:
       - wsl
- 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,12 +57,17 @@ services:
         BASE_IMAGE: ubuntu:24.04
         WITH_ROS: "false"
     environment:
+      # required to prevent excessive thread creation
+      OMP_NUM_THREADS: 4
+      # for X11 forwarding from container to host
+      DISPLAY: ${DISPLAY}
       # for WSLg in WSL2
       GALLIUM_DRIVER: d3d12
       MESA_D3D12_DEFAULT_ADAPTER_NAME: NVIDIA
       __NV_PRIME_RENDER_OFFLOAD: 1
     volumes:
       - /usr/lib/wsl:/usr/lib/wsl:ro
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
     profiles:
       - wsl
  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,72 @@
+# Reusable common service configs
+x-spark-common: &spark-common
+  stdin_open: true
+  tty: true
+  gpus: all
+  shm_size: 2g # increase shared memory size for MuJoCo
+  working_dir: /home/spark/spark
+  user: ${USER}:${USER}
+  environment:
+    # required to prevent excessive thread creation
+    OMP_NUM_THREADS: 4
+    OPENBLAS_NUM_THREADS: 1
+    MKL_NUM_THREADS: 1
+    NUMEXPR_NUM_THREADS: 1
+    BLIS_NUM_THREADS: 1 
+    # for X11 forwarding from container to host
+    DISPLAY: ${DISPLAY}
+  volumes:
+    - ./:/home/spark/spark
+    - /tmp/.X11-unix:/tmp/.X11-unix:rw
+    - ~/.Xauthority:/root/.Xauthority
+  command: /bin/bash
+
+services:
+  # Default Spark container (w/o ROS) 
+  spark:
+    <<: *spark-common
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: spark
+      args:
+        BASE_IMAGE: ubuntu:24.04
+        WITH_ROS: "false"
+      profiles:
+        - default
+
+  #  Spark container with ROS
+  spark-ros:
+    <<: *spark-common
+    build: 
+      context: .
+      dockerfile: Dockerfile
+      target: spark
+      args:
+        BASE_IMAGE: osrf/ros:jazzy-simulation
+        WITH_ROS: "true"
+    environment:
+      - ROS_DOMAIN_ID: 0
+    profiles:
+      - ros
+
+  # Spark container configured for WSL2 with NVIDIA GPU and WSLg OpenGL support
+  spark-wsl:
+    <<: *spark-common
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: spark
+      args:
+        BASE_IMAGE: ubuntu:24.04
+        WITH_ROS: "false"
+    environment:
+      # for WSLg in WSL2
+      GALLIUM_DRIVER: d3d12
+      MESA_D3D12_DEFAULT_ADAPTER_NAME: NVIDIA
+      __NV_PRIME_RENDER_OFFLOAD: 1
+    volumes:
+      - /usr/lib/wsl:/usr/lib/wsl:ro
+    profiles:
+      - wsl
+ 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,10 @@ x-spark-common: &spark-common
   gpus: all
   shm_size: 2g # increase shared memory size for MuJoCo
   working_dir: /home/spark/spark
-  user: ${USER}:${USER}
+  user: ${UID}:${UID}
   environment:
     # required to prevent excessive thread creation
     OMP_NUM_THREADS: 4
-    OPENBLAS_NUM_THREADS: 1
-    MKL_NUM_THREADS: 1
-    NUMEXPR_NUM_THREADS: 1
-    BLIS_NUM_THREADS: 1 
     # for X11 forwarding from container to host
     DISPLAY: ${DISPLAY}
   volumes:
@@ -32,8 +28,8 @@ services:
       args:
         BASE_IMAGE: ubuntu:24.04
         WITH_ROS: "false"
-      profiles:
-        - default
+    profiles:
+      - default
 
   #  Spark container with ROS
   spark-ros:
@@ -46,7 +42,7 @@ services:
         BASE_IMAGE: osrf/ros:jazzy-simulation
         WITH_ROS: "true"
     environment:
-      - ROS_DOMAIN_ID: 0
+      ROS_DOMAIN_ID: 0
     profiles:
       - ros
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ x-spark-common: &spark-common
   gpus: all
   shm_size: 2g # increase shared memory size for MuJoCo
   working_dir: /home/spark/spark
-  user: ${UID}:${UID}
+  user: ${UID_UID}
   environment:
     # required to prevent excessive thread creation
     OMP_NUM_THREADS: 4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,33 @@
 # Reusable common service configs
-x-spark-common: &spark-common
+x-service-common: &service-common
+  build: &build-common
+    context: .
+    dockerfile: Dockerfile
+    target: spark
   stdin_open: true
   tty: true
   gpus: all
   shm_size: 2g # increase shared memory size for MuJoCo
   working_dir: /home/spark/spark
   user: ${UID}:${UID}
-  environment:
+  environment: &env-common
     # required to prevent excessive thread creation
     OMP_NUM_THREADS: 4
     # for X11 forwarding from container to host
     DISPLAY: ${DISPLAY}
-  volumes:
+  volumes: 
     - ./:/home/spark/spark
     - /tmp/.X11-unix:/tmp/.X11-unix:rw
     - ~/.Xauthority:/root/.Xauthority
   command: /bin/bash
 
+
 services:
   # Default Spark container (w/o ROS) 
   spark:
-    <<: *spark-common
+    <<: *service-common
     build:
-      context: .
-      dockerfile: Dockerfile
-      target: spark
+      <<: *build-common
       args:
         BASE_IMAGE: ubuntu:24.04
         WITH_ROS: "false"
@@ -33,39 +36,34 @@ services:
 
   #  Spark container with ROS
   spark-ros:
-    <<: *spark-common
+    <<: *service-common
     build: 
-      context: .
-      dockerfile: Dockerfile
-      target: spark
+      <<: *build-common
       args:
         BASE_IMAGE: osrf/ros:jazzy-simulation
         WITH_ROS: "true"
     environment:
+      <<: *env-common
       ROS_DOMAIN_ID: 0
     profiles:
       - ros
 
   # Spark container configured for WSL2 with NVIDIA GPU and WSLg OpenGL support
   spark-wsl:
-    <<: *spark-common
+    <<: *service-common
     build:
-      context: .
-      dockerfile: Dockerfile
-      target: spark
+      <<: *build-common
       args:
         BASE_IMAGE: ubuntu:24.04
         WITH_ROS: "false"
     environment:
-      # required to prevent excessive thread creation
-      OMP_NUM_THREADS: 4
-      # for X11 forwarding from container to host
-      DISPLAY: ${DISPLAY}
+      <<: *env-common
       # for WSLg in WSL2
       GALLIUM_DRIVER: d3d12
       MESA_D3D12_DEFAULT_ADAPTER_NAME: NVIDIA
       __NV_PRIME_RENDER_OFFLOAD: 1
     volumes:
+      - ./:/home/spark/spark
       - /usr/lib/wsl:/usr/lib/wsl:ro
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       args:
         BASE_IMAGE: osrf/ros:jazzy-simulation
         WITH_ROS: "true"
+        PYTHON_VERSION: 3.12
     environment:
       <<: *env-common
       ROS_DOMAIN_ID: 0

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ function handle_error {
 # Default values
 INSTALL_ROS=false
 ENV_NAME=""
+PYTHON_VERSION="3.10"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -28,6 +29,14 @@ while [[ $# -gt 0 ]]; do
                 handle_error "You must provide an environment name after --name."
             fi
             ENV_NAME="$1"
+            shift
+            ;;
+      --python|--py)
+            shift
+            if [[ -z "$1" || "$1" == "--"* ]]; then
+              handle_error "You must provide a python version after --python (e.g. 3.10)."
+            fi
+            PYTHON_VERSION="$1"
             shift
             ;;
         *)
@@ -66,8 +75,8 @@ fi
 if [[ "$ENV_EXISTS" == true ]]; then
   echo "Step 1: Conda environment '$ENV_NAME' already exists. Activating it."
 else
-  echo "Step 1: Creating Conda environment: $ENV_NAME"
-  conda create --name $ENV_NAME "python=3.10" -y || handle_error "Failed to create Conda environment $ENV_NAME using 'conda create --name $ENV_NAME python=3.10'"
+  echo "Step 1: Creating Conda environment: $ENV_NAME (python=$PYTHON_VERSION)"
+  conda create --name "$ENV_NAME" "python=$PYTHON_VERSION" -y || handle_error "Failed to create Conda environment $ENV_NAME using 'conda create --name $ENV_NAME python=$PYTHON_VERSION'"
 fi
 
 # Step 2: Activate the environment

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,49 @@ cd unitree_sdk2_python
 pip install -e .
 ```
 
+### 1.3 Docker
+
+If using docker, local installation should be skipped as dependencies are installed in the docker container. Instead, see the docker section under "Quick Start". 
+
+#### Building the Image
+The container is built automatically (or started from the local cache) when starting a service listed in the `docker-compose.yml` config file. The container has miniconda3 installed, along with SPARK and it's dependencies. 
+
+If you want want to manually build an image, e.g., to give it an explicit tag, do so using the below command:
+
+```bash
+docker build --target spark -t <image_tag> --build-arg BASE_IMAGE=<base_image> --build-arg WITH_ROS=<with_ros> --build-arg PYTHON_VERSION=<python_version> .
+```
+The build args are explained as follows:
+
+- image_tag: the name for the image
+- BASE_IMAGE: the image used during the build stage when runtime and system dependencies are installed. Suggested values are: 
+  - a version of ubuntu (e.g., `ubuntu:24.04`),
+  - ros or osrf/ros image (e.g., `osrf/ros:jazzy-simulation`)
+- WITH_ROS: set to either `true` if using a ROS base image
+- PYTHON_VERSION: the python version for the conda environment created during installation
+  - If using a ROS base image, ensure this matches the python version required by the ROS distro in the base image (e.g., 3.12 for ROS jazzy) 
+
+#### Adding Additional Dependencies
+If desiring to add additional system dependencies/packages, such as ROS packages, add them to a new RUN command in the `Dockerfile`, within the `spark-base` build stage, for example:
+
+```dockerfile
+# Install ROS 2 dependencies
+# 
+RUN if [ "${WITH_ROS}" = "true" ]; then \
+    apt-get update && apt-get install -y --no-install-recommends \
+    ros-${ROS_DISTRO}-rviz2 \
+    ros-${ROS_DISTRO}-rviz-default-plugins \
+    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*; \
+    fi
+
+...
+
+CMD [ "/bin/bash" ]
+```
+
+
 ---
 ## 🚀 2 Quick Start
 
@@ -91,6 +134,15 @@ A quick example is:
 ```
 python example/run_g1_safe_teleop_sim.py
 ```
+
+if using docker:
+
+```bash
+./run_with_docker.sh default example/g1/run_g1_safe_teleop_sim.py
+```
+
+### not too great
+UID_UID=$(id -u):$(id -g) docker compose --profile default run spark conda init && activate spark && python example/g1/run_g1_safe_teleop_sim.py
 
 ### 2.2 Benchmark Pipeline
 To run a implemented [benchmark pipeline](pipeline/spark_pipeline/autonomy/benchmark_pipeline.py), you can run:
@@ -140,6 +192,26 @@ pipeline = Pipeline(cfg)
 # Run the pipeline
 pipeline.run()
 ```
+
+### 2.4 Docker 
+
+The `run_with_docker.sh` script is provided to simplify running pipelines in docker containers. To use the script, invoke it with the image variant and the path to the spark run file. 
+> See the installation section for more details on how the image variants are configured and built.
+
+```bash
+./run_with_docker.sh {ros|wsl|default} path/to/run/file
+```
+
+The run file path is relative to the root of the repo. So, to run the G1 Safe Teleoperation example within the default container variant, use:
+
+```bash
+./run_with_docker.sh default example/g1/run_g1_safe_teleop_sim.py
+```
+
+There are three container variants. :
+- default: use this if you don't need ROS
+- ros: use this if you need ROS
+- wsl: use this if you're running in WSL2 on Windows
 
 ---
 ## 🧩 3 Infrastructure

--- a/readme.md
+++ b/readme.md
@@ -141,9 +141,6 @@ if using docker:
 ./run_with_docker.sh default example/g1/run_g1_safe_teleop_sim.py
 ```
 
-### not too great
-UID_UID=$(id -u):$(id -g) docker compose --profile default run spark conda init && activate spark && python example/g1/run_g1_safe_teleop_sim.py
-
 ### 2.2 Benchmark Pipeline
 To run a implemented [benchmark pipeline](pipeline/spark_pipeline/autonomy/benchmark_pipeline.py), you can run:
 ```

--- a/run_with_docker.sh
+++ b/run_with_docker.sh
@@ -14,4 +14,4 @@ case "$profile" in
 		;;
 esac
 
-UID_UID=$(id -u):$(id -g) docker compose --profile "$profile" up "$@"
+UID_UID=$(id -u):$(id -g) docker compose run spark-${profile} "$@" 

--- a/run_with_docker.sh
+++ b/run_with_docker.sh
@@ -2,16 +2,29 @@
 
 set -euo pipefail
 
+usage (){
+	echo "Usage: $0 {ros|wsl|default} <spark-run-file>" >&2
+}
+
 profile="${1:-default}"
 
+# check for container variant
 case "$profile" in
 	ros|wsl|default)
 		shift || true
 		;;
 	*)
-		echo "Usage: $0 {ros|wsl|default} [docker-compose-args...]" >&2
+		usage
+		echo 'Must specify a container variant, e.g., "default"'
 		exit 1
 		;;
 esac
 
-UID_UID=$(id -u):$(id -g) docker compose run spark-${profile} "$@" 
+# check for run file
+if [[ $# -eq 0 ]]; then
+	usage
+	echo "Must specify a spark run file"
+	exit 1
+fi
+
+docker compose run --remove-orphans spark-${profile} bash -ic "source /root/.bashrc && python $1"

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+profile="${1:-default}"
+
+case "$profile" in
+	ros|wsl|default)
+		shift || true
+		;;
+	*)
+		echo "Usage: $0 {ros|wsl|default} [docker-compose-args...]" >&2
+		exit 1
+		;;
+esac
+
+UID_UID=$(id -u):$(id -g) docker compose --profile "$profile" up "$@"


### PR DESCRIPTION
## What Was Changed

(Summary of the technical approach and what functionality was added, changed, or fixed to resolve the ticket)

- Added a Docker-based workflow for SPARK with a multi-stage Dockerfile that builds a base runtime image with MuJoCo/OpenGL dependencies, CUDA tooling, Miniconda, and an optional ROS setup.
- Added docker-compose.yml service profiles for default, ros, and wsl container variants, including GPU/X11/WSL-specific runtime configuration.
- Added run_with_docker.sh to simplify launching example scripts inside the correct container profile with the repository mounted into the container.
- Updated the readme.md "Installation" and "Quick Start" sections with build instructions, usage examples, and guidance for choosing the correct container variant.

## Steps to Produce

(Step by step test instructions and descriptive success criteria to demonstrate MR functionality)

1. Build the default Docker image (or simply skip to step 2 and start the default profile.)
   - Command:
     ```bash
     docker compose --profile default build
     ```
   - Success Criteria: The image builds successfully without errors and produces a runnable `spark-default` container.

2. Run the sample safe teleoperation pipeline through the helper script.
   - Command:
     ```bash
     ./run_with_docker.sh default example/g1/run_g1_safe_teleop_sim.py
     ```
   - Success Criteria: The container starts, the conda environment is activated, and the example script launches from inside the container.

### For Other Image Variants
3. Repeat the run with the ROS profile if ROS support is needed.
   - Command:
     ```bash
     ./run_with_docker.sh ros example/g1/run_g1_safe_teleop_sim.py
     ```
   - Success Criteria: The ROS container builds/starts correctly, ROS setup is sourced, and the example runs with ROS dependencies available.

4. Verify the WSL profile if running on Windows/WSL2 with NVIDIA graphics.
  [running on WSL]
  - Command:
     ```bash
     ./run_with_docker.sh wsl example/g1/run_g1_safe_teleop_sim.py
     ```
   - Success Criteria: The container starts with WSL-specific mounts and environment variables, and rendering-related dependencies are available.

